### PR TITLE
Atualização dos modelos preditivos

### DIFF
--- a/notebooks/data-processing.ipynb
+++ b/notebooks/data-processing.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 522,
+   "execution_count": 1,
    "id": "c1a68699",
    "metadata": {},
    "outputs": [],
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 523,
+   "execution_count": 2,
    "id": "7bb097f3",
    "metadata": {},
    "outputs": [
@@ -38,7 +38,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\Raphael\\AppData\\Local\\Temp\\ipykernel_28508\\710402656.py:2: DtypeWarning: Columns (26) have mixed types. Specify dtype option on import or set low_memory=False.\n",
+      "C:\\Users\\Raphael\\AppData\\Local\\Temp\\ipykernel_41588\\710402656.py:2: DtypeWarning: Columns (26) have mixed types. Specify dtype option on import or set low_memory=False.\n",
       "  train_df = pd.read_csv('../data/raw/train.csv')\n"
      ]
     },
@@ -192,7 +192,7 @@
          "type": "string"
         }
        ],
-       "ref": "ce0ea5ca-160f-4df3-b6fe-f0d890479ae7",
+       "ref": "529800b3-af19-4f26-b4e8-61baefceffb9",
        "rows": [
         [
          "0",
@@ -562,7 +562,7 @@
        "[5 rows x 28 columns]"
       ]
      },
-     "execution_count": 523,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -575,7 +575,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 524,
+   "execution_count": 3,
    "id": "36102fe2",
    "metadata": {},
    "outputs": [
@@ -627,7 +627,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 525,
+   "execution_count": 4,
    "id": "da48965c",
    "metadata": {},
    "outputs": [
@@ -637,7 +637,7 @@
        "(100000, 28)"
       ]
      },
-     "execution_count": 525,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -712,7 +712,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 526,
+   "execution_count": 5,
    "id": "44d95cfe",
    "metadata": {},
    "outputs": [
@@ -731,7 +731,7 @@
          "type": "integer"
         }
        ],
-       "ref": "d0be2af4-8651-4e4a-861b-56340a09b54d",
+       "ref": "0e743c5d-2afe-4668-b60d-c581c71cabff",
        "rows": [
         [
          "ID",
@@ -883,7 +883,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 526,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -908,7 +908,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 527,
+   "execution_count": 6,
    "id": "0453ebd6",
    "metadata": {},
    "outputs": [
@@ -1062,7 +1062,7 @@
          "type": "string"
         }
        ],
-       "ref": "fec2cb95-7dab-4282-b5c8-838f71704bcf",
+       "ref": "347ad555-2b2d-4313-9664-3bee5727a9d4",
        "rows": [
         [
          "0",
@@ -1432,7 +1432,7 @@
        "[5 rows x 28 columns]"
       ]
      },
-     "execution_count": 527,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1446,7 +1446,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 528,
+   "execution_count": 7,
    "id": "55b5b86f",
    "metadata": {},
    "outputs": [
@@ -1465,7 +1465,7 @@
          "type": "integer"
         }
        ],
-       "ref": "721eb0b4-7499-485b-88a6-6edcdb06633e",
+       "ref": "8aff7229-6898-4acf-b110-ea6cf0c86813",
        "rows": [
         [
          "id",
@@ -1617,7 +1617,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 528,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1628,7 +1628,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 529,
+   "execution_count": 8,
    "id": "c63759df",
    "metadata": {},
    "outputs": [
@@ -1682,7 +1682,7 @@
          "type": "float"
         }
        ],
-       "ref": "aac4be99-1079-4929-a5ea-3b2572a94fc8",
+       "ref": "6c67f921-3c3c-4926-b8be-27b3933e7bfd",
        "rows": [
         [
          "count",
@@ -1932,7 +1932,7 @@
        "max                   50.000000         82331.000000  "
       ]
      },
-     "execution_count": 529,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1952,7 +1952,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 530,
+   "execution_count": 9,
    "id": "c4467ffa",
    "metadata": {},
    "outputs": [
@@ -2066,7 +2066,7 @@
          "type": "string"
         }
        ],
-       "ref": "b4341a1f-c93c-46ef-b483-f32d4caac034",
+       "ref": "1499f92d-2186-4c24-9215-496c73f9221f",
        "rows": [
         [
          "0",
@@ -2394,7 +2394,7 @@
        "4  High_spent_Medium_value_payments  341.48923103222177         Good  "
       ]
      },
-     "execution_count": 530,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2418,7 +2418,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 531,
+   "execution_count": 10,
    "id": "e53ad0f9",
    "metadata": {},
    "outputs": [
@@ -2437,7 +2437,7 @@
          "type": "integer"
         }
        ],
-       "ref": "68aa5d4b-fd87-4199-b442-ce51e0accd15",
+       "ref": "8d09c951-bfcd-4017-9eae-5e9332e62d1a",
        "rows": [
         [
          "age",
@@ -2549,7 +2549,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 531,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2568,7 +2568,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 532,
+   "execution_count": 11,
    "id": "634b322a",
    "metadata": {},
    "outputs": [
@@ -2578,7 +2578,7 @@
        "array(['23', '-500', '28_', ..., '4808_', '2263', '1342'], dtype=object)"
       ]
      },
-     "execution_count": 532,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2589,7 +2589,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 533,
+   "execution_count": 12,
    "id": "4aeacb09",
    "metadata": {},
    "outputs": [
@@ -2599,7 +2599,7 @@
        "array(['23', '500', '28', ..., '4808', '2263', '1342'], dtype=object)"
       ]
      },
-     "execution_count": 533,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2613,7 +2613,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 534,
+   "execution_count": 13,
    "id": "25d1aca0",
    "metadata": {},
    "outputs": [
@@ -2624,7 +2624,7 @@
        "       '39628.99_'], dtype=object)"
       ]
      },
-     "execution_count": 534,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2635,7 +2635,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 535,
+   "execution_count": 14,
    "id": "b09ca97c",
    "metadata": {},
    "outputs": [
@@ -2646,7 +2646,7 @@
        "       '39628.99'], dtype=object)"
       ]
      },
-     "execution_count": 535,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2659,7 +2659,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 536,
+   "execution_count": 15,
    "id": "1729e4e3",
    "metadata": {},
    "outputs": [
@@ -2669,7 +2669,7 @@
        "15002"
       ]
      },
-     "execution_count": 536,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2680,7 +2680,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 537,
+   "execution_count": 16,
    "id": "43de2783",
    "metadata": {},
    "outputs": [
@@ -2690,7 +2690,7 @@
        "0"
       ]
      },
-     "execution_count": 537,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2702,7 +2702,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 538,
+   "execution_count": 17,
    "id": "6848bbee",
    "metadata": {},
    "outputs": [],
@@ -2712,7 +2712,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 539,
+   "execution_count": 18,
    "id": "7913a42c",
    "metadata": {},
    "outputs": [
@@ -2722,7 +2722,7 @@
        "(100000, 20)"
       ]
      },
-     "execution_count": 539,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2733,7 +2733,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 540,
+   "execution_count": 19,
    "id": "a5e940b7",
    "metadata": {},
    "outputs": [
@@ -2791,7 +2791,7 @@
        "       '966'], dtype=object)"
       ]
      },
-     "execution_count": 540,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2802,7 +2802,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 541,
+   "execution_count": 20,
    "id": "94904235",
    "metadata": {},
    "outputs": [
@@ -2812,7 +2812,7 @@
        "dtype('O')"
       ]
      },
-     "execution_count": 541,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2825,7 +2825,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 542,
+   "execution_count": 21,
    "id": "227d4314",
    "metadata": {},
    "outputs": [
@@ -2839,7 +2839,7 @@
        "       40, 37, -5, -4, 66], dtype=int64)"
       ]
      },
-     "execution_count": 542,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2850,7 +2850,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 543,
+   "execution_count": 22,
    "id": "baa65457",
    "metadata": {},
    "outputs": [],
@@ -2860,7 +2860,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 544,
+   "execution_count": 23,
    "id": "a482fd67",
    "metadata": {},
    "outputs": [
@@ -2960,7 +2960,7 @@
        "       '2047'], dtype=object)"
       ]
      },
-     "execution_count": 544,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2971,7 +2971,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 545,
+   "execution_count": 24,
    "id": "ca3b52c1",
    "metadata": {},
    "outputs": [],
@@ -2983,7 +2983,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 546,
+   "execution_count": 25,
    "id": "22719c09",
    "metadata": {},
    "outputs": [
@@ -3079,7 +3079,7 @@
        "      dtype=object)"
       ]
      },
-     "execution_count": 546,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3090,7 +3090,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 547,
+   "execution_count": 26,
    "id": "8fd923dd",
    "metadata": {},
    "outputs": [
@@ -3100,7 +3100,7 @@
        "array(['_', 'Good', 'Standard', 'Bad'], dtype=object)"
       ]
      },
-     "execution_count": 547,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3111,7 +3111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 548,
+   "execution_count": 27,
    "id": "9cd5cac4",
    "metadata": {},
    "outputs": [],
@@ -3121,7 +3121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 549,
+   "execution_count": 28,
    "id": "5df7656d",
    "metadata": {},
    "outputs": [
@@ -3131,7 +3131,7 @@
        "array(['Other', 'Good', 'Standard', 'Bad'], dtype=object)"
       ]
      },
-     "execution_count": 549,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3142,7 +3142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 550,
+   "execution_count": 29,
    "id": "a129bc1c",
    "metadata": {},
    "outputs": [
@@ -3152,7 +3152,7 @@
        "array(['No', 'NM', 'Yes'], dtype=object)"
       ]
      },
-     "execution_count": 550,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3163,7 +3163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 551,
+   "execution_count": 30,
    "id": "9582d9ec",
    "metadata": {},
    "outputs": [],
@@ -3173,7 +3173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 552,
+   "execution_count": 31,
    "id": "5286f20f",
    "metadata": {},
    "outputs": [],
@@ -3183,7 +3183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 553,
+   "execution_count": 32,
    "id": "0015d013",
    "metadata": {},
    "outputs": [],
@@ -3193,7 +3193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 554,
+   "execution_count": 33,
    "id": "ec0c4c73",
    "metadata": {},
    "outputs": [
@@ -3203,7 +3203,7 @@
        "1209"
       ]
      },
-     "execution_count": 554,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3214,7 +3214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 555,
+   "execution_count": 34,
    "id": "b0118b4a",
    "metadata": {},
    "outputs": [],
@@ -3224,7 +3224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 556,
+   "execution_count": 35,
    "id": "d7d05d0b",
    "metadata": {},
    "outputs": [
@@ -3234,7 +3234,7 @@
        "0"
       ]
      },
-     "execution_count": 556,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3245,7 +3245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 557,
+   "execution_count": 36,
    "id": "46c5be0b",
    "metadata": {},
    "outputs": [
@@ -3255,7 +3255,7 @@
        "1965"
       ]
      },
-     "execution_count": 557,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3266,7 +3266,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 558,
+   "execution_count": 37,
    "id": "5ac414cb",
    "metadata": {},
    "outputs": [
@@ -3276,7 +3276,7 @@
        "0"
       ]
      },
-     "execution_count": 558,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3288,7 +3288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 559,
+   "execution_count": 38,
    "id": "4580038a",
    "metadata": {},
    "outputs": [],
@@ -3300,7 +3300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 560,
+   "execution_count": 39,
    "id": "4919e03b",
    "metadata": {},
    "outputs": [
@@ -3311,7 +3311,7 @@
        "      dtype=object)"
       ]
      },
-     "execution_count": 560,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3322,7 +3322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 561,
+   "execution_count": 40,
    "id": "b86d3210",
    "metadata": {},
    "outputs": [
@@ -3333,7 +3333,7 @@
        "       33.63820798, 34.19246265])"
       ]
      },
-     "execution_count": 561,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3344,7 +3344,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 562,
+   "execution_count": 41,
    "id": "c60eedbf",
    "metadata": {},
    "outputs": [
@@ -3355,7 +3355,7 @@
        "       1.21120000e+04, 3.51040226e+01, 5.86380000e+04])"
       ]
      },
-     "execution_count": 562,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3366,7 +3366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 563,
+   "execution_count": 42,
    "id": "3f488c4d",
    "metadata": {},
    "outputs": [
@@ -3378,7 +3378,7 @@
        "      dtype=object)"
       ]
      },
-     "execution_count": 563,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3389,7 +3389,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 564,
+   "execution_count": 43,
    "id": "d53efe05",
    "metadata": {},
    "outputs": [],
@@ -3399,7 +3399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 565,
+   "execution_count": 44,
    "id": "b66bab52",
    "metadata": {},
    "outputs": [
@@ -3409,7 +3409,7 @@
        "0"
       ]
      },
-     "execution_count": 565,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3420,7 +3420,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 566,
+   "execution_count": 45,
    "id": "c937908a",
    "metadata": {},
    "outputs": [
@@ -3431,7 +3431,7 @@
        "      dtype=object)"
       ]
      },
-     "execution_count": 566,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3442,7 +3442,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 567,
+   "execution_count": 46,
    "id": "be8f067a",
    "metadata": {},
    "outputs": [],
@@ -3452,7 +3452,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 568,
+   "execution_count": 47,
    "id": "dbad794a",
    "metadata": {},
    "outputs": [],
@@ -3462,7 +3462,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 569,
+   "execution_count": 48,
    "id": "f5e779b9",
    "metadata": {},
    "outputs": [
@@ -3481,7 +3481,7 @@
          "type": "integer"
         }
        ],
-       "ref": "9040fa13-a2c4-41ae-83f3-e98aeeaab344",
+       "ref": "98d08a8c-ec48-4617-b326-e4b9f7681a38",
        "rows": [
         [
          "age",
@@ -3593,7 +3593,7 @@
        "dtype: int64"
       ]
      },
-     "execution_count": 569,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3613,7 +3613,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 570,
+   "execution_count": 49,
    "id": "1a5cb7eb",
    "metadata": {},
    "outputs": [],
@@ -3624,7 +3624,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 571,
+   "execution_count": 50,
    "id": "df1f9e3e",
    "metadata": {},
    "outputs": [
@@ -3677,7 +3677,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 572,
+   "execution_count": 51,
    "id": "98a4a95d",
    "metadata": {},
    "outputs": [
@@ -3687,7 +3687,7 @@
        "0"
       ]
      },
-     "execution_count": 572,
+     "execution_count": 51,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3706,7 +3706,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 573,
+   "execution_count": 52,
    "id": "fadc323c",
    "metadata": {},
    "outputs": [
@@ -3875,7 +3875,7 @@
          "type": "integer"
         }
        ],
-       "ref": "aaca47cb-6a71-4b91-a216-d4625b83cd66",
+       "ref": "0a059a82-0ea6-4b9e-8204-620cb938b51c",
        "rows": [
         [
          "0",
@@ -4302,7 +4302,7 @@
        "[5 rows x 31 columns]"
       ]
      },
-     "execution_count": 573,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4317,7 +4317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 574,
+   "execution_count": 53,
    "id": "75f95435",
    "metadata": {},
    "outputs": [],
@@ -4328,7 +4328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 575,
+   "execution_count": 54,
    "id": "ea52856c",
    "metadata": {},
    "outputs": [
@@ -4350,7 +4350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 576,
+   "execution_count": 55,
    "id": "9bedebfa",
    "metadata": {},
    "outputs": [],
@@ -4360,7 +4360,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 577,
+   "execution_count": 56,
    "id": "9a7a7a39",
    "metadata": {},
    "outputs": [
@@ -4415,7 +4415,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 578,
+   "execution_count": 57,
    "id": "3c9dc832",
    "metadata": {},
    "outputs": [
@@ -4425,7 +4425,7 @@
        "(100000, 31)"
       ]
      },
-     "execution_count": 578,
+     "execution_count": 57,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4444,7 +4444,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 579,
+   "execution_count": 58,
    "id": "c1fcbed2",
    "metadata": {},
    "outputs": [],

--- a/notebooks/model-development.ipynb
+++ b/notebooks/model-development.ipynb
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 1,
    "id": "c935ca55",
    "metadata": {},
    "outputs": [],
@@ -62,17 +62,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 2,
    "id": "e90f4119",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Accessing as rrmoreira\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Accessing as rrmoreira\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "ds = datasources.get('rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring', 'processed')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 3,
    "id": "c55c3704",
    "metadata": {},
    "outputs": [
@@ -138,7 +152,7 @@
          "type": "integer"
         }
        ],
-       "ref": "5e1d9afc-0fe0-48e4-b915-03abee1816a2",
+       "ref": "a69cccbe-beff-4279-9ebb-d55725d683be",
        "rows": [
         [
          "0",
@@ -201,7 +215,7 @@
        "0  https://dagshub.com/api/v1/repos/rrmoreira/fia...  text/plain  14128312  "
       ]
      },
-     "execution_count": 62,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -212,7 +226,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 4,
    "id": "2d2e2088",
    "metadata": {},
    "outputs": [
@@ -253,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 5,
    "id": "8e38b35f",
    "metadata": {},
    "outputs": [
@@ -263,7 +277,7 @@
        "'https://dagshub.com/api/v1/repos/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring/raw/main/data/processed/credit-score-processed.csv'"
       ]
      },
-     "execution_count": 64,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -274,7 +288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 6,
    "id": "aec9f321",
    "metadata": {},
    "outputs": [
@@ -443,7 +457,7 @@
          "type": "integer"
         }
        ],
-       "ref": "8435f126-a57f-4919-bb97-526e9b173eeb",
+       "ref": "c741b310-30f1-4aa5-ace0-6963b869c3ea",
        "rows": [
         [
          "0",
@@ -870,7 +884,7 @@
        "[5 rows x 31 columns]"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -882,7 +896,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 7,
+   "id": "b10e8e65",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 100000 entries, 0 to 99999\n",
+      "Data columns (total 31 columns):\n",
+      " #   Column                                              Non-Null Count   Dtype  \n",
+      "---  ------                                              --------------   -----  \n",
+      " 0   age                                                 100000 non-null  int64  \n",
+      " 1   annual_income                                       100000 non-null  float64\n",
+      " 2   monthly_inhand_salary                               100000 non-null  float64\n",
+      " 3   num_bank_accounts                                   100000 non-null  int64  \n",
+      " 4   num_credit_card                                     100000 non-null  int64  \n",
+      " 5   interest_rate                                       100000 non-null  int64  \n",
+      " 6   num_of_loan                                         100000 non-null  int64  \n",
+      " 7   delay_from_due_date                                 100000 non-null  int64  \n",
+      " 8   num_of_delayed_payment                              100000 non-null  int64  \n",
+      " 9   changed_credit_limit                                100000 non-null  float64\n",
+      " 10  num_credit_inquiries                                100000 non-null  float64\n",
+      " 11  outstanding_debt                                    100000 non-null  float64\n",
+      " 12  credit_utilization_ratio                            100000 non-null  float64\n",
+      " 13  total_emi_per_month                                 100000 non-null  float64\n",
+      " 14  amount_invested_monthly                             100000 non-null  float64\n",
+      " 15  monthly_balance                                     100000 non-null  float64\n",
+      " 16  credit_score                                        100000 non-null  int64  \n",
+      " 17  credit_mix_bad                                      100000 non-null  int64  \n",
+      " 18  credit_mix_good                                     100000 non-null  int64  \n",
+      " 19  credit_mix_other                                    100000 non-null  int64  \n",
+      " 20  credit_mix_standard                                 100000 non-null  int64  \n",
+      " 21  payment_behaviour_high_spent_large_value_payments   100000 non-null  int64  \n",
+      " 22  payment_behaviour_high_spent_medium_value_payments  100000 non-null  int64  \n",
+      " 23  payment_behaviour_high_spent_small_value_payments   100000 non-null  int64  \n",
+      " 24  payment_behaviour_low_spent_large_value_payments    100000 non-null  int64  \n",
+      " 25  payment_behaviour_low_spent_medium_value_payments   100000 non-null  int64  \n",
+      " 26  payment_behaviour_low_spent_small_value_payments    100000 non-null  int64  \n",
+      " 27  payment_behaviour_other                             100000 non-null  int64  \n",
+      " 28  payment_of_min_amount_no                            100000 non-null  int64  \n",
+      " 29  payment_of_min_amount_other                         100000 non-null  int64  \n",
+      " 30  payment_of_min_amount_yes                           100000 non-null  int64  \n",
+      "dtypes: float64(9), int64(22)\n",
+      "memory usage: 23.7 MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "df.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "id": "b976f550",
    "metadata": {},
    "outputs": [
@@ -919,7 +988,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 9,
    "id": "4bb01fb5",
    "metadata": {},
    "outputs": [
@@ -927,12 +996,12 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025/08/02 13:29:49 WARNING mlflow.utils.autologging_utils: MLflow sklearn autologging is known to be compatible with 0.24.1 <= scikit-learn <= 1.5.2, but the installed version is 1.6.1. If you encounter errors during autologging, try upgrading / downgrading scikit-learn to a compatible version, or try upgrading MLflow.\n",
-      "2025/08/02 13:29:49 INFO mlflow.tracking.fluent: Autologging successfully enabled for sklearn.\n",
-      "2025/08/02 13:29:49 WARNING mlflow.utils.autologging_utils: MLflow lightgbm autologging is known to be compatible with 3.1.1 <= lightgbm <= 4.5.0, but the installed version is 4.6.0. If you encounter errors during autologging, try upgrading / downgrading lightgbm to a compatible version, or try upgrading MLflow.\n",
-      "2025/08/02 13:29:49 INFO mlflow.tracking.fluent: Autologging successfully enabled for lightgbm.\n",
-      "2025/08/02 13:29:49 WARNING mlflow.utils.autologging_utils: MLflow xgboost autologging is known to be compatible with 1.4.2 <= xgboost <= 2.1.2, but the installed version is 3.0.3. If you encounter errors during autologging, try upgrading / downgrading xgboost to a compatible version, or try upgrading MLflow.\n",
-      "2025/08/02 13:29:49 INFO mlflow.tracking.fluent: Autologging successfully enabled for xgboost.\n"
+      "2025/08/02 18:53:51 WARNING mlflow.utils.autologging_utils: MLflow sklearn autologging is known to be compatible with 0.24.1 <= scikit-learn <= 1.5.2, but the installed version is 1.6.1. If you encounter errors during autologging, try upgrading / downgrading scikit-learn to a compatible version, or try upgrading MLflow.\n",
+      "2025/08/02 18:53:52 INFO mlflow.tracking.fluent: Autologging successfully enabled for sklearn.\n",
+      "2025/08/02 18:53:52 WARNING mlflow.utils.autologging_utils: MLflow lightgbm autologging is known to be compatible with 3.1.1 <= lightgbm <= 4.5.0, but the installed version is 4.6.0. If you encounter errors during autologging, try upgrading / downgrading lightgbm to a compatible version, or try upgrading MLflow.\n",
+      "2025/08/02 18:53:52 INFO mlflow.tracking.fluent: Autologging successfully enabled for lightgbm.\n",
+      "2025/08/02 18:53:52 WARNING mlflow.utils.autologging_utils: MLflow xgboost autologging is known to be compatible with 1.4.2 <= xgboost <= 2.1.2, but the installed version is 3.0.3. If you encounter errors during autologging, try upgrading / downgrading xgboost to a compatible version, or try upgrading MLflow.\n",
+      "2025/08/02 18:53:52 INFO mlflow.tracking.fluent: Autologging successfully enabled for xgboost.\n"
      ]
     }
    ],
@@ -942,7 +1011,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 10,
    "id": "c0e08a9b",
    "metadata": {},
    "outputs": [],
@@ -953,7 +1022,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 11,
    "id": "43c9f7de",
    "metadata": {},
    "outputs": [
@@ -992,7 +1061,7 @@
        " 'payment_of_min_amount_yes']"
       ]
      },
-     "execution_count": 69,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1003,7 +1072,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 12,
    "id": "39ea9be7",
    "metadata": {},
    "outputs": [],
@@ -1013,7 +1082,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 13,
    "id": "2a09b4bc",
    "metadata": {},
    "outputs": [
@@ -1023,7 +1092,7 @@
        "30"
       ]
      },
-     "execution_count": 73,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1034,7 +1103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 14,
    "id": "a1ab8d80",
    "metadata": {},
    "outputs": [
@@ -1053,7 +1122,7 @@
          "type": "integer"
         }
        ],
-       "ref": "7df060d8-1742-48ad-a798-8008a5d9a9a5",
+       "ref": "9cb441da-aa3c-42fe-8cb1-afd3f3d2ba6f",
        "rows": [
         [
          "0",
@@ -1276,7 +1345,7 @@
        "Name: credit_score, Length: 100000, dtype: int64"
       ]
      },
-     "execution_count": 74,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1288,7 +1357,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 15,
    "id": "6037bcdc",
    "metadata": {},
    "outputs": [],
@@ -1298,12 +1367,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 16,
    "id": "1a6507ea",
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
+    "#Funcao para treinar e avaliar modelos\n",
     "\n",
     "def evaluate_and_log_model(kind, model_name, model, X_test, y_test):\n",
     "   predictions = model.predict(X_test)\n",
@@ -1354,7 +1423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 17,
    "id": "6d496c72",
    "metadata": {},
    "outputs": [
@@ -1362,8 +1431,32 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025/08/02 13:46:32 INFO mlflow.sklearn.utils: Logging the 5 best runs, 10 runs will be omitted.\n",
-      "Downloading artifacts: 100%|██████████| 7/7 [00:00<00:00, 87.79it/s] \n"
+      "2025/08/02 19:07:28 INFO mlflow.sklearn.utils: Logging the 5 best runs, 10 runs will be omitted.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "🏃 View run overjoyed-fox-627 at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/373118fd29684575bced9746a95d09f4\n",
+      "🧪 View experiment at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0\n",
+      "🏃 View run big-sloth-614 at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/75b626f2c8fe4bdbbd949d654f584df2\n",
+      "🧪 View experiment at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0\n",
+      "🏃 View run dazzling-lark-779 at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/61d658dff2e04f0bb080c78328570940\n",
+      "🧪 View experiment at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0\n",
+      "🏃 View run peaceful-cub-259 at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/d924e02bf4ff4e13b6bb83c8ab11f86e\n",
+      "🧪 View experiment at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0\n",
+      "🏃 View run upset-shark-813 at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/b57c8e4c0c6446edb46c713dda20efe0\n",
+      "🧪 View experiment at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\Raphael\\anaconda3\\envs\\tf-env\\Lib\\site-packages\\tqdm\\auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n",
+      "Downloading artifacts: 100%|██████████| 7/7 [00:00<00:00, 439.67it/s]\n"
      ]
     },
     {
@@ -1371,7 +1464,43 @@
      "output_type": "stream",
      "text": [
       "Model RandomForest Classifier logged with Accuracy: 0.7064, Precision: 0.7155461725618537, Recall: 0.7064, F1: 0.7085011173160016\n",
-      "🏃 View run RandomForest Classifier at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/d3f321d5361446289055e1b33b5db018\n",
+      "🏃 View run RandomForest Classifier at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/31c822aca3254282b18ae6b6e04d3598\n",
+      "🧪 View experiment at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "🏃 View run chill-lark-130 at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/0f0dad2b8c0345689d89d8bce44c65e3\n",
+      "🧪 View experiment at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0\n",
+      "🏃 View run carefree-fish-686 at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/5511f26fc2854dd296c7535ca237557c\n",
+      "🧪 View experiment at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0\n",
+      "🏃 View run puzzled-sloth-792 at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/40ea06311975416c836d054d4ebbb451\n",
+      "🧪 View experiment at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0\n",
+      "🏃 View run righteous-lamb-770 at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/fd6fe4ae84d241efa103a6c80623a805\n",
+      "🧪 View experiment at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0\n",
+      "🏃 View run likeable-dove-607 at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/b3707f78f6e543afb65755e488a95ff2\n",
+      "🧪 View experiment at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0\n",
+      "🏃 View run adventurous-smelt-82 at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/0d8d42ed8787425486bce940da12179c\n",
+      "🧪 View experiment at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0\n",
+      "🏃 View run industrious-bass-603 at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/54d7bb777e3f4abb9df65193ba332ffb\n",
+      "🧪 View experiment at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0\n",
+      "🏃 View run fun-yak-168 at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/cd384ef6651b4d33b48654a100e5f607\n",
+      "🧪 View experiment at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0\n",
+      "🏃 View run gifted-snipe-181 at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/2691eda0bc5c4cbda1f3a44a42053a03\n",
+      "🧪 View experiment at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0\n",
+      "🏃 View run clean-crane-76 at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/0d1511a3426b402395de42d5141ed43f\n",
+      "🧪 View experiment at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0\n",
+      "🏃 View run gifted-doe-470 at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/a8bfd57dd7fc49e597e0f0101c765254\n",
+      "🧪 View experiment at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0\n",
+      "🏃 View run rebellious-crow-955 at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/9ddbc43e92654f8fa5ebe5b62ac0729e\n",
+      "🧪 View experiment at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0\n",
+      "🏃 View run big-goose-770 at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/fb927878cca34285ad03cac34e05f9c3\n",
+      "🧪 View experiment at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0\n",
+      "🏃 View run gifted-ant-756 at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/554a600f15174d21bef1e884b559563e\n",
+      "🧪 View experiment at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0\n",
+      "🏃 View run monumental-jay-336 at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/b4830ab77b92420a84c80f2d8e312f17\n",
       "🧪 View experiment at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0\n"
      ]
     }
@@ -1408,7 +1537,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 18,
    "id": "5167890b",
    "metadata": {},
    "outputs": [
@@ -1416,8 +1545,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025/08/02 13:53:08 INFO mlflow.sklearn.utils: Logging the 5 best runs, 7 runs will be omitted.\n",
-      "Downloading artifacts: 100%|██████████| 7/7 [00:00<?, ?it/s]\n"
+      "2025/08/02 19:11:48 INFO mlflow.sklearn.utils: Logging the 5 best runs, 7 runs will be omitted.\n",
+      "Downloading artifacts: 100%|██████████| 7/7 [00:00<00:00, 303.99it/s]\n"
      ]
     },
     {
@@ -1425,7 +1554,7 @@
      "output_type": "stream",
      "text": [
       "Model Decision Tree Classifier logged with Accuracy: 0.6467333333333334, Precision: 0.6896280841575652, Recall: 0.6467333333333334, F1: 0.6515327649968193\n",
-      "🏃 View run DecisionTree_Classifier at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/0f7b401b07284abaa85251105ce91124\n",
+      "🏃 View run DecisionTree_Classifier at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/70108323ba134f4fa02642e6646772fc\n",
       "🧪 View experiment at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0\n"
      ]
     }
@@ -1458,7 +1587,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 19,
    "id": "0ac53f39",
    "metadata": {},
    "outputs": [
@@ -3656,45 +3785,41 @@
       "ValueError: l1_ratio must be specified when penalty is elasticnet.\n",
       "\n",
       "  warnings.warn(some_fits_failed_message, FitFailedWarning)\n",
-      "c:\\Users\\Raphael\\anaconda3\\envs\\tf-env\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [       nan 0.53287143 0.51907143 0.53287143        nan        nan\n",
-      " 0.51838571 0.53287143        nan 0.53287143 0.52914286 0.53287143\n",
-      "        nan        nan 0.5283     0.53287143        nan 0.53287143\n",
-      " 0.53382857 0.53287143        nan        nan 0.53598571 0.53287143\n",
-      "        nan 0.53287143 0.51825714 0.53287143        nan        nan\n",
-      " 0.51838571 0.53287143        nan 0.53287143 0.52982857 0.53287143\n",
-      "        nan        nan 0.5283     0.53287143        nan 0.53287143\n",
-      " 0.53937143 0.53287143        nan        nan 0.53598571 0.53287143\n",
-      "        nan 0.53287143 0.51838571 0.53287143        nan        nan\n",
-      " 0.51838571 0.53287143        nan 0.53287143 0.52914286 0.53287143\n",
-      "        nan        nan 0.5283     0.53287143        nan 0.53287143\n",
-      " 0.53861429 0.53287143        nan        nan 0.53598571 0.53287143\n",
-      "        nan 0.53287143 0.51838571 0.53287143        nan        nan\n",
-      " 0.51838571 0.53287143        nan 0.53287143 0.5292     0.53287143\n",
-      "        nan        nan 0.5283     0.53287143        nan 0.53287143\n",
-      " 0.53477143 0.53287143        nan        nan 0.53598571 0.53287143]\n",
+      "c:\\Users\\Raphael\\anaconda3\\envs\\tf-env\\Lib\\site-packages\\sklearn\\model_selection\\_search.py:1108: UserWarning: One or more of the test scores are non-finite: [       nan 0.53287143 0.53207143 0.53287143        nan        nan\n",
+      " 0.53207143 0.53287143        nan 0.53287143 0.51907143 0.53287143\n",
+      "        nan        nan 0.51838571 0.53287143        nan 0.53287143\n",
+      " 0.52914286 0.53287143        nan        nan 0.5283     0.53287143\n",
+      "        nan 0.53287143 0.53207143 0.53287143        nan        nan\n",
+      " 0.53207143 0.53287143        nan 0.53287143 0.51825714 0.53287143\n",
+      "        nan        nan 0.51838571 0.53287143        nan 0.53287143\n",
+      " 0.52982857 0.53287143        nan        nan 0.5283     0.53287143\n",
+      "        nan 0.53287143 0.53207143 0.53287143        nan        nan\n",
+      " 0.53207143 0.53287143        nan 0.53287143 0.51838571 0.53287143\n",
+      "        nan        nan 0.51838571 0.53287143        nan 0.53287143\n",
+      " 0.52914286 0.53287143        nan        nan 0.5283     0.53287143\n",
+      "        nan 0.53287143 0.53207143 0.53287143        nan        nan\n",
+      " 0.53207143 0.53287143        nan 0.53287143 0.51838571 0.53287143\n",
+      "        nan        nan 0.51838571 0.53287143        nan 0.53287143\n",
+      " 0.5292     0.53287143        nan        nan 0.5283     0.53287143]\n",
       "  warnings.warn(\n",
       "c:\\Users\\Raphael\\anaconda3\\envs\\tf-env\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:1247: FutureWarning: 'multi_class' was deprecated in version 1.5 and will be removed in 1.7. From then on, it will always use 'multinomial'. Leave it to its default value to avoid this warning.\n",
       "  warnings.warn(\n",
-      "c:\\Users\\Raphael\\anaconda3\\envs\\tf-env\\Lib\\site-packages\\sklearn\\linear_model\\_logistic.py:465: ConvergenceWarning: lbfgs failed to converge (status=1):\n",
-      "STOP: TOTAL NO. of ITERATIONS REACHED LIMIT.\n",
-      "\n",
-      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
-      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
-      "Please also refer to the documentation for alternative solver options:\n",
-      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
-      "  n_iter_i = _check_optimize_result(\n",
+      "c:\\Users\\Raphael\\anaconda3\\envs\\tf-env\\Lib\\site-packages\\sklearn\\linear_model\\_sag.py:348: ConvergenceWarning: The max_iter was reached which means the coef_ did not converge\n",
+      "  warnings.warn(\n",
       "c:\\Users\\Raphael\\anaconda3\\envs\\tf-env\\Lib\\site-packages\\sklearn\\metrics\\_classification.py:1565: UndefinedMetricWarning: Precision is ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.\n",
       "  _warn_prf(average, modifier, f\"{metric.capitalize()} is\", len(result))\n",
-      "2025/08/02 14:21:51 INFO mlflow.sklearn.utils: Logging the 5 best runs, 91 runs will be omitted.\n",
-      "Downloading artifacts: 100%|██████████| 7/7 [00:00<00:00, 12258.93it/s]\n"
+      "2025/08/02 19:36:24 INFO mlflow.sklearn.utils: Logging the 5 best runs, 91 runs will be omitted.\n",
+      "c:\\Users\\Raphael\\anaconda3\\envs\\tf-env\\Lib\\site-packages\\sklearn\\metrics\\_classification.py:1565: UndefinedMetricWarning: Precision is ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.\n",
+      "  _warn_prf(average, modifier, f\"{metric.capitalize()} is\", len(result))\n",
+      "Downloading artifacts: 100%|██████████| 7/7 [00:00<00:00, 438.23it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Model Logistic Regression logged with Accuracy: 0.5296333333333333, Precision: 0.6085676481718, Recall: 0.5296333333333333, F1: 0.4739281755383046\n",
-      "🏃 View run Logistic Regression at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/1f78e5ece43145dfa5e3aca2fca24526\n",
+      "Model Logistic Regression logged with Accuracy: 0.5291, Precision: 0.27994681, Recall: 0.5291, F1: 0.3661589300895952\n",
+      "🏃 View run Logistic Regression at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/78f05de153904245af5e427abfb75af3\n",
       "🧪 View experiment at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0\n"
      ]
     }
@@ -3705,7 +3830,7 @@
     "        'penalty': ['l1', 'l2', 'elasticnet', None],\n",
     "        'C': [0.01, 0.1, 1, 10],\n",
     "        'solver': ['lbfgs', 'saga'],\n",
-    "        'max_iter': [50, 100, 150]\n",
+    "        'max_iter': [10, 50, 100]\n",
     "    }\n",
     "    logreg = LogisticRegression(random_state=42, multi_class='auto')\n",
     "    grid_search = GridSearchCV(logreg, param_grid, cv=5, scoring=make_scorer(accuracy_score))\n",
@@ -3730,7 +3855,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 20,
    "id": "d9112723",
    "metadata": {},
    "outputs": [
@@ -3738,10 +3863,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025/08/02 14:33:09 INFO mlflow.sklearn.utils: Logging the 5 best runs, 43 runs will be omitted.\n",
-      "c:\\Users\\Raphael\\anaconda3\\envs\\tf-env\\Lib\\site-packages\\xgboost\\sklearn.py:1028: UserWarning: [14:33:45] WARNING: C:\\actions-runner\\_work\\xgboost\\xgboost\\src\\c_api\\c_api.cc:1427: Saving model in the UBJSON format as default.  You can use file extension: `json`, `ubj` or `deprecated` to choose between formats.\n",
+      "2025/08/02 19:46:20 INFO mlflow.sklearn.utils: Logging the 5 best runs, 43 runs will be omitted.\n",
+      "c:\\Users\\Raphael\\anaconda3\\envs\\tf-env\\Lib\\site-packages\\xgboost\\sklearn.py:1028: UserWarning: [19:46:53] WARNING: C:\\actions-runner\\_work\\xgboost\\xgboost\\src\\c_api\\c_api.cc:1427: Saving model in the UBJSON format as default.  You can use file extension: `json`, `ubj` or `deprecated` to choose between formats.\n",
       "  self.get_booster().save_model(fname)\n",
-      "Downloading artifacts: 100%|██████████| 7/7 [00:00<00:00, 248.43it/s]\n"
+      "Downloading artifacts: 100%|██████████| 7/7 [00:00<00:00, 301.29it/s]\n"
      ]
     },
     {
@@ -3749,7 +3874,7 @@
      "output_type": "stream",
      "text": [
       "Model XGBoost Classifier logged with Accuracy: 0.7717333333333334, Precision: 0.7712228163212964, Recall: 0.7717333333333334, F1: 0.771321317952736\n",
-      "🏃 View run XGBoost Classifier at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/92b59800347c422bb681fd7d8c1957a4\n",
+      "🏃 View run XGBoost Classifier at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/9fb9bd9355f445af85c49c0b499e51e3\n",
       "🧪 View experiment at: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0\n"
      ]
     }
@@ -3785,7 +3910,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 21,
    "id": "8c64240c",
    "metadata": {},
    "outputs": [
@@ -3793,26 +3918,26 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Successfully registered model 'credit-scoring-model'.\n",
-      "2025/08/02 14:40:59 INFO mlflow.store.model_registry.abstract_store: Waiting up to 300 seconds for model version to finish creation. Model name: credit-scoring-model, version 1\n",
-      "Created version '1' of model 'credit-scoring-model'.\n"
+      "Registered model 'credit-scoring-model' already exists. Creating a new version of this model...\n",
+      "2025/08/02 19:48:36 INFO mlflow.store.model_registry.abstract_store: Waiting up to 300 seconds for model version to finish creation. Model name: credit-scoring-model, version 2\n",
+      "Created version '2' of model 'credit-scoring-model'.\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<ModelVersion: aliases=[], creation_timestamp=1754156459126, current_stage='None', description='', last_updated_timestamp=1754156459126, name='credit-scoring-model', run_id='92b59800347c422bb681fd7d8c1957a4', run_link='', source='mlflow-artifacts:/a13a12126d67478588e03dcde0482475/92b59800347c422bb681fd7d8c1957a4/artifacts/model', status='READY', status_message='', tags={}, user_id='', version='1'>"
+       "<ModelVersion: aliases=[], creation_timestamp=1754174916645, current_stage='None', description='', last_updated_timestamp=1754174916645, name='credit-scoring-model', run_id='9fb9bd9355f445af85c49c0b499e51e3', run_link='', source='mlflow-artifacts:/a13a12126d67478588e03dcde0482475/9fb9bd9355f445af85c49c0b499e51e3/artifacts/model', status='READY', status_message='', tags={}, user_id='', version='2'>"
       ]
      },
-     "execution_count": 82,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "#View run XGBoost Classifier - melhor modelo: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/92b59800347c422bb681fd7d8c1957a4\n",
+    "#View run XGBoost Classifier - melhor modelo: https://dagshub.com/rrmoreira/fiap-ds-mlops-9dtsr-credit-scoring.mlflow/#/experiments/0/runs/9fb9bd9355f445af85c49c0b499e51e3\n",
     "\n",
-    "run_id = '92b59800347c422bb681fd7d8c1957a4'\n",
+    "run_id = '9fb9bd9355f445af85c49c0b499e51e3'\n",
     "\n",
     "mlflow.register_model(\n",
     "    model_uri=f\"runs:/{run_id}/model\",\n",


### PR DESCRIPTION
Atualização dos modelos com base nos novos experimentos:

Model RandomForest Classifier logged with 
**Accuracy: 0.7064, 
Precision: 0.7155461725618537, 
Recall: 0.7064, 
F1: 0.7085011173160016**

Obs. Tive que voltar para o modelo do RandomForest (v3) devido a um problema que deu na execução da lambda function decorrente do modelo XGBoost:

<!--StartFragment-->
var/lang/lib/python3.10/site-packages/xgboost/core.py:377: FutureWarning: **Your system has an old version of glibc (< 2.28). We will stop supporting Linux distros with glibc older than 2.28 after **May 31, 2025**. Please upgrade to a recent Linux distro (with glibc >= 2.28) to use future versions of XGBoost.**
--
  | 2025-08-03T00:49:03.328Z | Note: You have installed the 'manylinux2014' variant of XGBoost. Certain features such as GPU algorithms or federated learning are not available. To use these features, please upgrade to a recent Linux distro with glibc 2.28+, and install the 'manylinux_2_28' variant.
  | 2025-08-03T00:49:03.328Z | warnings.warn(
  | 2025-08-03T00:49:04.720Z | INIT_REPORT Init Duration: 9691.56 ms Phase: init Status: error Error Type: Runtime.ExitError

<!--EndFragment-->


Como nao consegui resolver o probelma decidi por escolher este modelo mesmo nao sendo o melhor, inclusive tentei aumentar a memoria e mudar a versao do python para 3.11 e 3.12 e nao funcionou. Ao mudar para o RandomForest tive que incluir o pacote do ski-learn na imagem.
